### PR TITLE
Close transport on asyncio client disconnect

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -134,6 +134,7 @@ class MPDClient(MPDClientBase):
             self.__run_task.cancel()
         if self.__idle_task is not None:
             self.__idle_task.cancel()
+        self.__wfile.close()
         self.__rfile = self.__wfile = None
         self.__run_task = self.__idle_task = None
         self.__commandqueue = self.__command_enqueued = None


### PR DESCRIPTION
The current disconnect method of  asyncio.MPDClient does not close the writing transport. A warning for this is issued when running the python3 interpreter with -Wdefault. As a result, the MPD server keeps alive the connection to the client unnecessarily. If this happens repeatedly, the dangling connections may cause the MPD server to reach its maximal connection limit.

A minimal working example to elicit the warning is:

    import asyncio
    from mpd.asyncio import MPDClient
    
    async def main():
        client = MPDClient()
        try:
            await client.connect('localhost', 6600)
        except Exception as e:
            print("Connection failed:", e)
            return
    
        # Uncommenting the next line gets rid of the warning
        # client._MPDClient__wfile.close()
        client.disconnect()
            
    if __name__ == '__main__':
        loop = asyncio.get_event_loop()
        loop.run_until_complete(main())
        loop.close()

The above script with must be called `python3 -Wdefault` to see the resource warning. Uncommenting the command `client._MPDClient__wfile.close()` avoids the warning.